### PR TITLE
adds a new authenticate() call that can work with a credentials param…

### DIFF
--- a/src/main/java/com/acciente/oacc/AccessControlContext.java
+++ b/src/main/java/com/acciente/oacc/AccessControlContext.java
@@ -71,6 +71,22 @@ public interface AccessControlContext {
    void authenticate(Resource resource, Credentials credentials);
 
    /**
+    * Authenticates this security session using only security credentials.
+    * <p/>
+    * This authentication method requires a custom authentication provider and is not supported by the built-in
+    * authentication provider. It is intended for use where the resource identification is embedded in the credentials,
+    * such as in authentication protocols using encrypted authentication tokens. When using this method the custom
+    * authentication provider must return the resource to OACC from the custom authentication provider implementation.
+    * <p/>
+    * Note: Unless a session is authenticated, all attempts to call any other methods (except <code>authenticate</code>) will fail.
+    *
+    * @param credentials the credentials to authenticate the session
+    * @throws java.lang.IllegalArgumentException        if the resource does not exist or is not of an authenticatable resource class
+    * @throws com.acciente.oacc.AuthenticationException if authentication fails
+    */
+   void authenticate(Credentials credentials);
+
+   /**
     * Authenticates this security session against an {@link AuthenticationProvider} without
     * specifying authentication credentials, if that AuthenticationProvider supports such an operation.
     * <p/>

--- a/src/main/java/com/acciente/oacc/AuthenticationProvider.java
+++ b/src/main/java/com/acciente/oacc/AuthenticationProvider.java
@@ -46,6 +46,19 @@ public interface AuthenticationProvider {
    void authenticate(Resource resource);
 
    /**
+    * Authenticates the specified resource using the supplied credentials.
+    * <p/>
+    * This authentication method requires a custom authentication provider and is not supported by the built-in
+    * authentication provider. It is intended for use where the resource identification is embedded in the credentials,
+    * such as in authentication protocols using encrypted authentication tokens. When using this method the custom
+    * authentication provider must return the resource to OACC from the custom authentication provider implementation.
+    *
+    * @param credentials the credentials to authenticate the resource
+    * @throws com.acciente.oacc.IncorrectCredentialsException if authentication failed due to incorrect credentials
+    */
+   Resource authenticate(Credentials credentials);
+
+   /**
     * Checks if the the authentication credentials are valid for the specified resource class and domain.
     * <p/>
     * This method may check if the credentials satisfy the minimum strength requirements, for example.

--- a/src/main/java/com/acciente/oacc/sql/internal/SQLPasswordAuthenticationProvider.java
+++ b/src/main/java/com/acciente/oacc/sql/internal/SQLPasswordAuthenticationProvider.java
@@ -140,7 +140,14 @@ public class SQLPasswordAuthenticationProvider implements AuthenticationProvider
 
    @Override
    public void authenticate(Resource resource) {
-      throw new UnsupportedOperationException("The built-in password authentication provider does not support authentication without credentials");
+      throw new UnsupportedOperationException(
+            "The built-in password authentication provider does not support authentication without credentials");
+   }
+
+   @Override
+   public Resource authenticate(Credentials credentials) {
+      throw new UnsupportedOperationException(
+            "The built-in password authentication provider does not support authentication using *only* credentials");
    }
 
    private void __authenticate(SQLConnection connection, Resource resource, char[] password) {


### PR DESCRIPTION
…eter alone (i.e. no resource parameter)

The new authenticate() call now allows for a custom authentication provider implementation to support a scheme where the identity of the authenticated resource is embedded in the credentials; for example, a web API where the authenticated API caller is identified via an encrypted token in an HTTP header.